### PR TITLE
Aditional backslash in custom Dockerfiles was causing syntax errors

### DIFF
--- a/infrastructure/custom/memcached/Dockerfile
+++ b/infrastructure/custom/memcached/Dockerfile
@@ -1,7 +1,7 @@
 FROM ciandt/memcached:acquia-latest
 
 # define Docker image label information
-LABEL com.ciandt.vendor="Custom Vendor" \
+LABEL com.ciandt.vendor="Custom Vendor"
 
 # defines root user, to perform privileged operations
 USER root

--- a/infrastructure/custom/percona/Dockerfile
+++ b/infrastructure/custom/percona/Dockerfile
@@ -1,7 +1,7 @@
 FROM ciandt/percona:acquia-latest
 
 # define Docker image label information
-LABEL com.ciandt.vendor="Custom Vendor" \
+LABEL com.ciandt.vendor="Custom Vendor"
 
 # defines root user, to perform privileged operations
 USER root

--- a/infrastructure/custom/php/Dockerfile
+++ b/infrastructure/custom/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM ciandt/php:acquia-latest
 
 # define Docker image label information
-LABEL com.ciandt.vendor="Custom Vendor" \
+LABEL com.ciandt.vendor="Custom Vendor"
 
 # defines root user, to perform privileged operations
 USER root

--- a/infrastructure/custom/solr/Dockerfile
+++ b/infrastructure/custom/solr/Dockerfile
@@ -1,7 +1,7 @@
 FROM ciandt/solr:acquia-latest
 
 # define Docker image label information
-LABEL com.ciandt.vendor="Custom Vendor" \
+LABEL com.ciandt.vendor="Custom Vendor"
 
 # defines root user, to perform privileged operations
 USER root


### PR DESCRIPTION
If docker-compose.yml is changed to build custom Dockerfiles (commenting "image" and uncommenting "build" ), the file examples provided give the following error:

```
...
Building web
ERROR: Syntax error - can't find = in "USER". Must be of the form: name=value
  _______________________________________________________________________________

  -- Docker Build

  ERROR!!
  Something happened, your Docker image(s) were not built
....
```

There are missing backslashes in example Dockerfiles that need to be removed.